### PR TITLE
feature/exit country

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk --no-cache --no-progress --quiet upgrade && \
     apk --no-cache --no-progress --quiet add tor bash privoxy haproxy curl sed && \
     #
     # directories and files
-    mv /tor.cfg /etc/tor/torrc && \
+    mv /tor.cfg /etc/tor/torrc.default && \
     mv /privoxy.cfg /etc/privoxy/config.templ && \
     mv /haproxy.cfg /etc/haproxy/haproxy.cfg.default && \
     chmod +x /start.sh && \
@@ -40,4 +40,4 @@ RUN apk --no-cache --no-progress --quiet upgrade && \
     # kernel tunables
     rm -rf /etc/sysctl* /etc/modprobe.d /etc/modules /etc/mdev.conf /etc/acpi
 
-CMD /start.sh
+CMD ["/start.sh"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This Docker image provides one HTTP proxy endpoint with many IP addresses for us
 
 ![Screenshot](https://raw.githubusercontent.com/zhaow-de/rotating-tor-http-proxy/main/images/screenshot_1.gif)
 
-Behind the scene, it has an HAProxy sitting in front of multiple pairs of Privoxy-Tor. The HAProxy dispatches the incoming
+Behind the scene, it has a HAProxy sitting in front of multiple pairs of Privoxy-Tor. The HAProxy dispatches the incoming
 requests to the Privoxy instances with a round-robin strategy. 
 
 ## Usage
@@ -30,19 +30,79 @@ At the host, `127.0.0.1:3128` is the HTTP/HTTPS proxy address.
 ### Moreover
 
 ```shell
-docker run --rm -it -p 3128:3128 -p 4444:4444 -e "TOR_INSTANCES=5" -e "TOR_REBUILD_INTERVAL=3600" zhaowde/rotating-tor-http-proxy
+docker run --rm -it -p 3128:3128 -p 4444:4444 -e "TOR_INSTANCES=5" -e "TOR_REBUILD_INTERVAL=3600" -e "TOR_EXIT_COUNTRY=de,ch,at" zhaowde/rotating-tor-http-proxy
 ```
+
+#### Port `4444/TCP`
 
 Port `4444/TCP` can be mapped to the host if HAProxy stats information is needed. With `docker run -p 4444:4444`, the HAProxy statistics
 report is available at http://127.0.0.1:4444.  An [article](https://www.haproxy.com/blog/exploring-the-haproxy-stats-page/) from the
 HAProxy official blog explains in detail how to understand this report.
 
+#### `TOR_INSTANCES`
+
 Environment variable `TOR_INSTANCES` can be used to config the number of concurrent Tor clients (as well as the associated Privoxy 
 instances). The default is 10, and the valid value is purposely limited to the range between 1 and 40. 
 
+#### `TOR_REBUILD_INTERVAL`
 Each Tor client attempts to build a new circuit (results in a new outbound IP address) every 30 seconds. Every 30 minutes, this image
 rebuilds all the circuits. This interval can be changed with environment variable `TOR_REBUILD_INTERVAL`, the default value is 1800
 seconds, while it can be set up any number greater than 600 seconds.
+
+#### `TOR_EXIT_COUNTRY`
+
+For some crawling tasks, it requires limiting the IP addresses to a certain country to avoid triggering the unnecessary recaptcha verification. 
+Environment variable `TOR_EXIT_COUNTRY` can be used to specify a country (or a list of countries).
+Please note the following remarks:
+ * **Note 1**: Modifying the way that Tor creates its circuits is strongly discouraged, overriding the entry/exit nodes can compromise the anonymity.
+ * **Note 2**: The tor bridge is configured to strictly respect the exit countries if it is specified.
+   For the countries with too fewer exit nodes (e.g., Switzerland), it would take significantly longer time to build up the circuit.
+ * **Note 3**: The environment variable accepts a single country code (e.g., `TOR_EXIT_COUNTRY=de`) or a comma-separated list (e.g., `TOR_EXIT_COUNTRY=de,at,ch`)
+ * **Note 4**: The acceptable country codes:
+
+   | Country                               | Code | Country                   | Code | Country                               | Code | Country                     | Code | Country                       | Code        | Country                      | Code |
+   |---------------------------------------|------|---------------------------|------|---------------------------------------|------|-----------------------------|------|-------------------------------|-------------|------------------------------|------|
+   | ASCENSION ISLAND                      | `ac` | AFGHANISTAN               | `af` | ALAND                                 | `ax` | ALBANIA                     | `al` | ALGERIA                       | `dz`        | ANDORRA                      | `ad` |
+   | ANGOLA                                | `ao` | ANGUILLA                  | `ai` | ANTARCTICA                            | `aq` | ANTIGUA AND BARBUDA         | `ag` | ARGENTINA REPUBLIC            | `ar`        | ARMENIA                      | `am` |
+   | ARUBA                                 | `aw` | AUSTRALIA                 | `au` | AUSTRIA                               | `at` | AZERBAIJAN                  | `az` | BAHAMAS                       | `bs`        | BAHRAIN                      | `bh` |
+   | BANGLADESH                            | `bd` | BARBADOS                  | `bb` | BELARUS                               | `by` | BELGIUM                     | `be` | BELIZE                        | `bz`        | BENIN                        | `bj` |
+   | BERMUDA                               | `bm` | BHUTAN                    | `bt` | BOLIVIA                               | `bo` | BOSNIA AND HERZEGOVINA      | `ba` | BOTSWANA                      | `bw`        | BOUVET ISLAND                | `bv` |
+   | BRAZIL                                | `br` | BRITISH INDIAN OCEAN TERR | `io` | BRITISH VIRGIN ISLANDS                | `vg` | BRUNEI DARUSSALAM           | `bn` | BULGARIA                      | `bg`        | BURKINA FASO                 | `bf` |
+   | BURUNDI                               | `bi` | CAMBODIA                  | `kh` | CAMEROON                              | `cm` | CANADA                      | `ca` | CAPE VERDE                    | `cv`        | CAYMAN ISLANDS               | `ky` |
+   | CENTRAL AFRICAN REPUBLIC              | `cf` | CHAD                      | `td` | CHILE                                 | `cl` | PEOPLE'S REPUBLIC OF CHINA  | `cn` | CHRISTMAS ISLANDS             | `cx`        | COCOS ISLANDS                | `cc` |
+   | COLOMBIA                              | `co` | COMORAS                   | `km` | CONGO                                 | `cg` | CONGO (DEMOCRATIC REPUBLIC) | `cd` | COOK ISLANDS                  | `ck`        | COSTA RICA                   | `cr` |
+   | COTE D IVOIRE                         | `ci` | CROATIA                   | `hr` | CUBA                                  | `cu` | CYPRUS                      | `cy` | CZECH REPUBLIC                | `cz`        | DENMARK                      | `dk` |
+   | DJIBOUTI                              | `dj` | DOMINICA                  | `dm` | DOMINICAN REPUBLIC                    | `do` | EAST TIMOR                  | `tp` | ECUADOR                       | `ec` 	EGYPT | `eg`                         |
+   | EL SALVADOR                           | `sv` | EQUATORIAL GUINEA         | `gq` | ESTONIA                               | `ee` | ETHIOPIA                    | `et` | FALKLAND ISLANDS              | `fk`        | FAROE ISLANDS                | `fo` |
+   | FIJI                                  | `fj` | FINLAND                   | `fi` | FRANCE                                | `fr` | FRANCE METROPOLITAN         | `fx` | FRENCH GUIANA                 | `gf`        | FRENCH POLYNESIA             | `pf` |
+   | FRENCH SOUTHERN TERRITORIES           | `tf` | GABON                     | `ga` | GAMBIA                                | `gm` | GEORGIA                     | `ge` | GERMANY                       | `de`        | GHANA                        | `gh` |
+   | GIBRALTER                             | `gi` | GREECE                    | `gr` | GREENLAND                             | `gl` | GRENADA                     | `gd` | GUADELOUPE                    | `gp`        | GUAM                         | `gu` |
+   | GUATEMALA                             | `gt` | GUINEA                    | `gn` | GUINEA-BISSAU                         | `gw` | GUYANA                      | `gy` | HAITI                         | `ht`        | HEARD & MCDONALD ISLAND      | `hm` |
+   | HONDURAS                              | `hn` | HONG KONG                 | `hk` | HUNGARY                               | `hu` | ICELAND                     | `is` | INDIA                         | `in`        | INDONESIA                    | `id` |
+   | IRAN, ISLAMIC REPUBLIC OF             | `ir` | IRAQ                      | `iq` | IRELAND                               | `ie` | ISLE OF MAN                 | `im` | ISRAEL                        | `il`        | ITALY                        | `it` |
+   | JAMAICA                               | `jm` | JAPAN                     | `jp` | JORDAN                                | `jo` | KAZAKHSTAN                  | `kz` | KENYA                         | `ke`        | KIRIBATI                     | `ki` |
+   | KOREA, DEM. PEOPLES REP OF            | `kp` | KOREA, REPUBLIC OF        | `kr` | KUWAIT                                | `kw` | KYRGYZSTAN                  | `kg` | LAO PEOPLE'S DEM. REPUBLIC    | `la`        | LATVIA                       | `lv` |
+   | LEBANON                               | `lb` | LESOTHO                   | `ls` | LIBERIA                               | `lr` | LIBYAN ARAB JAMAHIRIYA      | `ly` | LIECHTENSTEIN                 | `li`        | LITHUANIA                    | `lt` |
+   | LUXEMBOURG                            | `lu` | MACAO                     | `mo` | MACEDONIA                             | `mk` | MADAGASCAR                  | `mg` | MALAWI                        | `mw`        | MALAYSIA                     | `my` |
+   | MALDIVES                              | `mv` | MALI                      | `ml` | MALTA                                 | `mt` | MARSHALL ISLANDS            | `mh` | MARTINIQUE                    | `mq`        | MAURITANIA                   | `mr` |
+   | MAURITIUS                             | `mu` | MAYOTTE                   | `yt` | MEXICO                                | `mx` | MICRONESIA                  | `fm` | MOLDAVA REPUBLIC OF           | `md`        | MONACO                       | `mc` |
+   | MONGOLIA                              | `mn` | MONTENEGRO                | `me` | MONTSERRAT                            | `ms` | MOROCCO                     | `ma` | MOZAMBIQUE                    | `mz`        | MYANMAR                      | `mm` |
+   | NAMIBIA                               | `na` | NAURU                     | `nr` | NEPAL                                 | `np` | NETHERLANDS ANTILLES        | `an` | NETHERLANDS, THE              | `nl`        | NEW CALEDONIA                | `nc` |
+   | NEW ZEALAND                           | `nz` | NICARAGUA                 | `ni` | NIGER                                 | `ne` | NIGERIA                     | `ng` | NIUE                          | `nu`        | NORFOLK ISLAND               | `nf` |
+   | NORTHERN MARIANA ISLANDS              | `mp` | NORWAY                    | `no` | OMAN                                  | `om` | PAKISTAN                    | `pk` | PALAU                         | `pw`        | PALESTINE                    | `ps` |
+   | PANAMA                                | `pa` | PAPUA NEW GUINEA          | `pg` | PARAGUAY                              | `py` | PERU                        | `pe` | PHILIPPINES (REPUBLIC OF THE) | `ph`        | PITCAIRN                     | `pn` |
+   | POLAND                                | `pl` | PORTUGAL                  | `pt` | PUERTO RICO                           | `pr` | QATAR                       | `qa` | REUNION                       | `re`        | ROMANIA                      | `ro` |
+   | RUSSIAN FEDERATION                    | `ru` | RWANDA                    | `rw` | SAMOA                                 | `ws` | SAN MARINO                  | `sm` | SAO TOME/PRINCIPE             | `st`        | SAUDI ARABIA                 | `sa` |
+   | SCOTLAND                              | `uk` | SENEGAL                   | `sn` | SERBIA                                | `rs` | SEYCHELLES                  | `sc` | SIERRA LEONE                  | `sl`        | SINGAPORE                    | `sg` |
+   | SLOVAKIA                              | `sk` | SLOVENIA                  | `si` | SOLOMON ISLANDS                       | `sb` | SOMALIA                     | `so` | SOMOA,GILBERT,ELLICE ISLANDS  | `as`        | SOUTH AFRICA                 | `za` |
+   | SOUTH GEORGIA, SOUTH SANDWICH ISLANDS | `gs` | SOVIET UNION              | `su` | SPAIN                                 | `es` | SRI LANKA                   | `lk` | ST. HELENA                    | `sh`        | ST. KITTS AND NEVIS          | `kn` |
+   | ST. LUCIA                             | `lc` | ST. PIERRE AND MIQUELON   | `pm` | ST. VINCENT & THE GRENADINES          | `vc` | SUDAN                       | `sd` | SURINAME                      | `sr`        | SVALBARD AND JAN MAYEN       | `sj` |
+   | SWAZILAND                             | `sz` | SWEDEN                    | `se` | SWITZERLAND                           | `ch` | SYRIAN ARAB REPUBLIC        | `sy` | TAIWAN                        | `tw`        | TAJIKISTAN                   | `tj` |
+   | TANZANIA, UNITED REPUBLIC OF          | `tz` | THAILAND                  | `th` | TOGO                                  | `tg` | TOKELAU                     | `tk` | TONGA                         | `to`        | TRINIDAD AND TOBAGO          | `tt` |
+   | TUNISIA                               | `tn` | TURKEY                    | `tr` | TURKMENISTAN                          | `tm` | TURKS AND CALCOS ISLANDS    | `tc` | TUVALU                        | `tv`        | UGANDA                       | `ug` |
+   | UKRAINE                               | `ua` | UNITED ARAB EMIRATES      | `ae` | UNITED KINGDOM (no new registrations) | `gb` | UNITED KINGDOM              | `uk` | UNITED STATES                 | `us`        | UNITED STATES MINOR OUTL.IS. | `um` |
+   | URUGUAY                               | `uy` | UZBEKISTAN                | `uz` | VANUATU                               | `vu` | VATICAN CITY STATE          | `va` | VENEZUELA                     | `ve`        | VIET NAM                     | `vn` |
+   | VIRGIN ISLANDS (USA)                  | `vi` | WALLIS AND FUTUNA ISLANDS | `wf` | WESTERN SAHARA                        | `eh` | YEMEN                       | `ye` | ZAMBIA                        | `zm`        | ZIMBABWE                     | `zw` |
 
 ### Test the proxy
 
@@ -52,8 +112,8 @@ while :; do curl -sx localhost:3128 ifconfig.io; echo ""; sleep 2; done
 
 ## Credit
 
-At Github, there are many repos build Docker image to provide HTTP proxy connects to the Tor network. The project is reinventing the wheel
-based on many of them.
+At GitHub, there are many repos build Docker images to provide HTTP proxy connects to the Tor network.
+The project is reinventing the wheels based on many of them.
 Remarkably:
 - [y4ns0l0/docker-multi-tor](https://github.com/y4ns0l0/docker-multi-tor) creates a setup with multiple pairs of Privoxy-Tor. Having no
   HAProxy-like dispatcher, each Privoxy expose itself to the host as a different TCP port.

--- a/start.sh
+++ b/start.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 
 function log() {
-   if [[ $# == 1 ]]; then
-      level="info"
-      msg=$1
-   elif [[ $# == 2 ]]; then
-      level=$1
-      msg=$2
-   fi
-   echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ") [controller] [${level}] ${msg}"
+    if [[ $# == 1 ]]; then
+        level="info"
+        msg=$1
+    elif [[ $# == 2 ]]; then
+        level=$1
+        msg=$2
+    fi
+    echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ") [controller] [${level}] ${msg}"
 }
 
 if ((TOR_INSTANCES < 1 || TOR_INSTANCES > 40)); then
-   log "fatal" "Environment variable TOR_INSTANCES has to be within the range of 1...40"
-   exit 1
+    log "fatal" "Environment variable TOR_INSTANCES has to be within the range of 1...40"
+    exit 1
 fi
 
 if ((TOR_REBUILD_INTERVAL < 600)); then
-   log "fatal" "Environment variable TOR_REBUILD_INTERVAL has to be bigger than 600 seconds"
-   # otherwise AWS may complain about it, because http://checkip.amazonaws.com is asked too often
-   exit 2
+    log "fatal" "Environment variable TOR_REBUILD_INTERVAL has to be bigger than 600 seconds"
+    # otherwise AWS may complain about it, because http://checkip.amazonaws.com is asked too often
+    exit 2
 fi
 
 base_tor_socks_port=10000
@@ -30,65 +30,92 @@ log "Start creating a pool of ${TOR_INSTANCES} tor instances..."
 
 # "reset" the HAProxy config file because it may contain the previous Privoxy instances information from the previous docker run
 cp /etc/haproxy/haproxy.cfg.default /etc/haproxy/haproxy.cfg
+# same "reset" logic as above
+cp /etc/tor/torrc.default /etc/tor/torrc
+
+if [[ -n $TOR_EXIT_COUNTRY ]]; then
+    IFS=', ' read -r -a countries <<< "$TOR_EXIT_COUNTRY"
+    value=""
+    is_first=1
+    for country in "${countries[@]}"
+    do
+        country=$(xargs <<< "$country")
+        length=${#country}
+        if [[ $length -ne 2 ]]; then
+            continue
+        fi
+        if [[ $is_first -ne 1 ]]; then
+            value="$value,"
+        else
+            is_first=0
+        fi
+        value="$value{$country}"
+    done
+    country_str=$(tr '[:upper:]' '[:lower:]' <<< "$value")
+    if [[ -n $country_str ]]; then
+        echo ExitNodes "$country_str" StrictNodes 1 >> /etc/tor/torrc
+        log "Limited the exit nodes to countries: \"${TOR_EXIT_COUNTRY}\""
+    fi
+fi
 
 for ((i = 0; i < TOR_INSTANCES; i++)); do
-   #
-   # start one tor instance
-   #
-   socks_port=$((base_tor_socks_port + i))
-   ctrl_port=$((base_tor_ctrl_port + i))
-   tor_data_dir="/var/local/tor/${i}"
-   mkdir -p "${tor_data_dir}" && chmod -R 700 "${tor_data_dir}" && chown -R tor: "${tor_data_dir}"
-   # spawn a child process to run the tor server at foreground so that logging to stdout is possible
-   (tor --PidFile "${tor_data_dir}/tor.pid" \
+    #
+    # start one tor instance
+    #
+    socks_port=$((base_tor_socks_port + i))
+    ctrl_port=$((base_tor_ctrl_port + i))
+    tor_data_dir="/var/local/tor/${i}"
+    mkdir -p "${tor_data_dir}" && chmod -R 700 "${tor_data_dir}" && chown -R tor: "${tor_data_dir}"
+    # spawn a child process to run the tor server at foreground so that logging to stdout is possible
+    (tor --PidFile "${tor_data_dir}/tor.pid" \
       --SocksPort 127.0.0.1:"${socks_port}" \
       --ControlPort 127.0.0.1:"${ctrl_port}" \
       --dataDirectory "${tor_data_dir}" 2>&1 |
       sed -r "s/^(\w+\ [0-9 :\.]+)(\[.*)[\r\n]?$/$(date -u +"%Y-%m-%dT%H:%M:%SZ") [tor#${i}] \2/") &
-   #
-   # start one privoxy instance connecting to the tor socks
-   #
-   http_port=$((base_http_port + i))
-   privoxy_data_dir="/var/local/privoxy/${i}"
-   mkdir -p "${privoxy_data_dir}" && chown -R privoxy: "${privoxy_data_dir}"
-   cp /etc/privoxy/config.templ "${privoxy_data_dir}/config"
-   sed -i \
+    #
+    # start one privoxy instance connecting to the tor socks
+    #
+    http_port=$((base_http_port + i))
+    privoxy_data_dir="/var/local/privoxy/${i}"
+    mkdir -p "${privoxy_data_dir}" && chown -R privoxy: "${privoxy_data_dir}"
+    cp /etc/privoxy/config.templ "${privoxy_data_dir}/config"
+    sed -i \
       -e 's@PLACEHOLDER_CONFDIR@'"${privoxy_data_dir}"'@g' \
       -e 's@PLACEHOLDER_HTTP_PORT@'"${http_port}"'@g' \
       -e 's@PLACEHOLDER_SOCKS_PORT@'"${socks_port}"'@g' \
       "${privoxy_data_dir}/config"
-   # spawn a child process
-   (privoxy \
+    # spawn a child process
+    (privoxy \
       --no-daemon \
       --user privoxy \
       --pidfile "${privoxy_data_dir}/privoxy.pid" \
       "${privoxy_data_dir}/config" 2>&1 |
       sed -r "s/^([0-9\-]+\ [0-9:\.]+\ [0-9a-f]+\ )([^:]+):\ (.*)[\r\n]?$/$(date -u +"%Y-%m-%dT%H:%M:%SZ") [privoxy#${i}] [\L\2] \E\3/") &
-   #
-   # "register" the privoxy instance to haproxy
-   #
-   echo "  server privoxy${i} 127.0.0.1:${http_port} check" >>/etc/haproxy/haproxy.cfg
+    #
+    # "register" the privoxy instance to haproxy
+    #
+    echo "  server privoxy${i} 127.0.0.1:${http_port} check" >>/etc/haproxy/haproxy.cfg
 done
 #
 # start an HAProxy instance
 #
 (haproxy -db -- /etc/haproxy/haproxy.cfg 2>&1 |
-   sed -r "s/^(\[[^]]+]\ )?([\ 0-9\/\():]+)?(.*)[\r\n]?$/$(date -u +"%Y-%m-%dT%H:%M:%SZ") [haproxy] \L\1\E\3/") &
+  sed -r "s/^(\[[^]]+]\ )?([\ 0-9\/\():]+)?(.*)[\r\n]?$/$(date -u +"%Y-%m-%dT%H:%M:%SZ") [haproxy] \L\1\E\3/") &
 # seems like haproxy starts logging only when the first request processed. We wait 15 seconds to build the first circuit then issue a
 # request to "activate" the HAProxy
 log "Wait 15 seconds to build the first Tor circuit"
 sleep 15
-curl -sx "http://127.0.0.1:3128" https://google.com >/dev/null
+curl -sx "http://127.0.0.1:3128" https://www.apple.com >/dev/null
 #
 # endless loop to reset circuits
 #
 while :; do
-   log "Wait ${TOR_REBUILD_INTERVAL} seconds to rebuild all the tor circuits"
-   sleep "$((TOR_REBUILD_INTERVAL))"
-   log "Rebuilding all the tor circuits..."
-   for ((i = 0; i < TOR_INSTANCES; i++)); do
-      http_port=$((base_http_port + i))
-      IP=$(curl -sx "http://127.0.0.1:${http_port}" http://checkip.amazonaws.com)
-      log "Current external IP address of proxy #${i}/${TOR_INSTANCES}: ${IP}"
-   done
+    log "Wait ${TOR_REBUILD_INTERVAL} seconds to rebuild all the tor circuits"
+    sleep "$((TOR_REBUILD_INTERVAL))"
+    log "Rebuilding all the tor circuits..."
+    for ((i = 0; i < TOR_INSTANCES; i++)); do
+        http_port=$((base_http_port + i))
+        IP=$(curl -sx "http://127.0.0.1:${http_port}" http://checkip.amazonaws.com)
+        log "Current external IP address of proxy #${i}/${TOR_INSTANCES}: ${IP}"
+    done
 done


### PR DESCRIPTION
Add environment variable `TOR_EXIT_COUNTRY` to limit the exit nodes to specified countries.

This PR solves https://github.com/zhaow-de/rotating-tor-http-proxy/issues/12 and https://github.com/zhaow-de/rotating-tor-http-proxy/issues/1